### PR TITLE
Prevent accidental refresh

### DIFF
--- a/app/components/ascii-art-generator.tsx
+++ b/app/components/ascii-art-generator.tsx
@@ -96,6 +96,29 @@ export function AsciiArtGenerator() {
   const lastProcessedSettings = useRef<AsciiSettings | null>(null)
   const isInitialMount = useRef(true)
 
+  const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+    // Trigger the warning dialog when the user closes or navigates the tab
+    event.preventDefault()
+  }
+
+  useEffect(() => {
+    // Check if the user has loaded some media or modified the code
+    const isSourceDirty =
+      (settings.source.type !== 'code' && settings.source.data !== null) ||
+      pendingCode !== DEFAULT_SETTINGS.source.code
+
+    if (isSourceDirty) {
+      window.addEventListener('beforeunload', handleBeforeUnload)
+    } else {
+      // Remove when not needed to minimize the effect on performance
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [settings, pendingCode])
+
   useEffect(() => {
     // Skip processing on initial mount
     if (isInitialMount.current) {


### PR DESCRIPTION

![Screenshot From 2025-05-07 17-14-54](https://github.com/user-attachments/assets/889df8f8-0aba-479a-bc10-939d5d66b396)

Modified `<AsciiArtGenerator />` to include a new `useEffect` that adds or removes the `'beforeunload'` event listener, with the intention of triggering a warning dialog in case any of the generator sources were modified.
